### PR TITLE
fix: restore coverage generation for coveralls

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build": "tsc",
         "build:release": "del-cli dist && del-cli coverage && pnpm run lint && pnpm run build",
         "test": "vitest",
-        "test:coverage": "pnpm test -- --coverage",
+        "test:coverage": "vitest --coverage",
         "lint": "biome check . && tsc --project tsconfig.lint.json --noEmit",
         "lint:fix": "biome check --write .",
         "prepublishOnly": "pnpm run build:release"


### PR DESCRIPTION
## Problem

The `coverage` workflow has been failing on `main` since #64 (pnpm 11 migration), reporting `🚨 Nothing to report`.

## Root cause

The `test:coverage` script was `pnpm test -- --coverage`. pnpm forwards the `--` verbatim into the nested `test` script, so CI actually ran:

```
$ vitest "--" "--coverage"
```

vitest treats everything after `--` as positional filename filters, so the `--coverage` flag was never applied and no `coverage/` directory was created. `coveralls report` then found `coverage/lcov.info` missing and failed the job.

It worked under npm because `npm run test:coverage` strips the `--` before forwarding; pnpm 11 does not.

## Fix

Call vitest directly so the stray `--` is never introduced:

```diff
-  "test:coverage": "pnpm test -- --coverage",
+  "test:coverage": "vitest --coverage",
```

Verified locally: the old script produced no `coverage/` dir; the new one runs `vitest --coverage`, prints the coverage report, and writes `coverage/lcov.info`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
